### PR TITLE
Support Nim v1.6.x to avoid breaking dependant packages

### DIFF
--- a/otp.nimble
+++ b/otp.nimble
@@ -1,11 +1,11 @@
 [Package]
 name          = "OTP"
-version       = "0.2.0"
+version       = "0.2.1"
 author        = "Huy Doan"
 description   = "One Time Password library for Nim"
 license       = "MIT"
 
 [Deps]
-Requires: "nim >= 2.0.0"
+Requires: "nim >= 1.6.10"
 Requires: "hmac >= 0.3.0"
 Requires: "base32"


### PR DESCRIPTION
@baf03, would it possible to revert this package Nim-requirement?

It still compiles for me with older Nim versions, so I just get breaks from other CI's not updated to Nim 2.0