### PR TITLE
Reduce amount of heap allocated types making it more secure

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Usage
 ```nim
 import otp
 
-let htop = newHotp("S3cret")
+let htop = Hotp.init("S3cret")
 assert hotp.at(0) == 755224
 assert hotp.at(1) == 287082
 
@@ -26,11 +26,11 @@ assert htop.verify(755224, 0) == true
 
 echo hotp.provisioning_uri("mark@percival")
 
-var totp = newTotp("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ")
+var totp = Totp.init("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ")
 assert totp.at(1111111111) == 50471
 assert totp.at(1234567890) == 5924
 assert totp.at(2000000000) == 279037
 
-totp = newTotp("blahblah")
+totp = Totp.init("blahblah")
 echo totp.now()
 ```

--- a/otp.nimble
+++ b/otp.nimble
@@ -1,6 +1,6 @@
 [Package]
 name          = "otp"
-version       = "0.2.2"
+version       = "0.2.3"
 author        = "Huy Doan"
 description   = "One Time Password library for Nim"
 license       = "MIT"
@@ -9,4 +9,4 @@ skipDirs      = @["tests"]
 [Deps]
 Requires: "nim >= 1.6.10"
 Requires: "hmac >= 0.3.1"
-Requires: "base32"
+Requires: "base32 >= 0.1.3"

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -1,6 +1,6 @@
 import otp
 
-var hotp = newHotp("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ")
+var hotp = Hotp.init("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ")
 assert hotp.at(0) == 755224
 assert hotp.at(1) == 287082
 assert hotp.at(2) == 359152
@@ -20,14 +20,14 @@ assert hotp.verify(520489, 10) == false
 #assert hotp.provisioningUri("mark@percival") == "otpauth://hotp/mark@percival?secret=wrn3pqx5uqxqvnqr&counter=0"
 
 
-var totp = newTotp("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ")
+var totp = Totp.init("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ")
 assert totp.at(1111111111) == 50471
 assert totp.at(1234567890) == 5924
 assert totp.at(2000000000) == 279037
 
 
-totp = newTotp("wrn3pqx5uqxqvnqr")
+totp = Totp.init("wrn3pqx5uqxqvnqr")
 assert totp.at(1297553958) == 102705
 
-totp = newTotp("blahblah")
+totp = Totp.init("blahblah")
 echo totp.now()

--- a/tests/test_issue4.nim
+++ b/tests/test_issue4.nim
@@ -1,5 +1,5 @@
 import otp
-var totp = newTotp("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ")
+var totp = Totp.init("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ")
 assert totp.at(1111111111) == 50471
 assert totp.at(1234567890) == 5924
 assert totp.at(2000000000) == 279037


### PR DESCRIPTION
This PR removes `ref object` as it's not needed and it just increases the chance of a heap attack. It also disables copies on the objects to prevent accidentally keeping the secret in memory at multiple places. Finally it bumps nimble versions and pins base32. This is a breaking change but hopefully for the better :sweat_smile: 