### PR TITLE
Use stack_strings for secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ assert totp.at(2000000000) == 279037
 totp = Totp.init("blahblah")
 echo totp.now()
 ```
+
+This library uses the wonderful [stack_strings](https://github.com/termermc/nim-stack-strings) library for secrets.
+Meaning secrets are fixed length one can use `--otp.secretSize:50` to override the size.
+By default the secret length is 32 bytes.

--- a/otp.nimble
+++ b/otp.nimble
@@ -1,6 +1,6 @@
 [Package]
 name          = "otp"
-version       = "0.3.0"
+version       = "0.3.1"
 author        = "Huy Doan"
 description   = "One Time Password library for Nim"
 license       = "MIT"
@@ -10,3 +10,4 @@ skipDirs      = @["tests"]
 Requires: "nim >= 1.6.10"
 Requires: "hmac >= 0.3.1"
 Requires: "base32 >= 0.1.3"
+Requires: "stack_strings >= 1.1.2"


### PR DESCRIPTION
Here's that aforementioned PR. Like I said though this means that if someone has a 33 byte secret they just cannot use OTP if the author of the program did not compile it with `-d:opt.secretSize: 33`. Also perhaps that defect should be an exception so programs can recover gracefully.