### PR TITLE
raise default secret size to 128

### DIFF
--- a/otp.nim
+++ b/otp.nim
@@ -14,7 +14,7 @@ from math import pow
 from times import epochTime
 import stack_strings as stackstrings
 
-const secretSize* {.intDefine: "otp.secretSize".} = 32
+const secretSize* {.intDefine: "otp.secretSize".} = 128
 
 type
   OneTimePasswordDefect = object of Defect


### PR DESCRIPTION
```
04:50 AM <termer> Elegantbeef, Gitea uses a 64 char TOTP secret
04:50 AM <termer> I'm thinking Nim OTP should have 64 as its default, not 32
04:51 AM <FromDiscord> <Elegantbeef> PR's welcome
04:51 AM <termer> All right
04:51 AM <FromDiscord> <Elegantbeef> Fuck it do 128 by default 😛
```